### PR TITLE
Cambio en el botón de exportar censo en ExportByVoting

### DIFF
--- a/decide/census/templates/exportCensusByVoting.html
+++ b/decide/census/templates/exportCensusByVoting.html
@@ -24,7 +24,7 @@
                 
                 <button href="" type="submit"  value="Submit" class="btn btn-warning a-btn-slide-text">
                     <span class="glyphicon glyphicon-ok-sign" aria-hidden="true"></span>
-                    <span><strong>{% trans 'Exportar Censos' %}</strong></span>
+                    <span><strong>{% trans 'Exportar Censo' %}</strong></span>
                   </button>
             </form>
             <br/><br/>


### PR DESCRIPTION
Se ha cambiado el botón de exportar censos en ExportByVoting a exportar censo.